### PR TITLE
Doc: redifinition initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,50 @@ string_store = StringStore.new
 end
 ```
 
+### Usage with complicated classes
+
+If class that includes GenericActor have `initialize` method, it should call GenericActors `initialize` explicitely. 
+In other case, dead lock will ocure on any `call_def` function call, and all `cast_def` function calls will newer be executed. 
+
+Example : 
+
+
+```
+class Welcoming
+  include GenericActor
+  @welcome : String
+  def initialize(@welcome)
+  end
+
+  call_def welcome, {guest: String}, Nil do
+    puts "#{@welcome} #{guest}"
+  end
+end
+
+friendly = Welcoming.new("Hello")
+friendly.welcome(guest: "world") # deadlock
+```
+
+Fix: 
+```
+class Welcoming
+  include GenericActor
+  @welcome : String
+  def initialize(@welcome)
+    # Call GenericActor initialize
+    # to start GenericActor's fiber
+    initialize
+  end
+
+  call_def welcome, {guest: String}, Nil do
+    puts "#{@welcome} #{guest}"
+  end
+end
+
+friendly = Welcoming.new("Hello")
+friendly.welcome(guest: "world") # deadlock
+```
+
 ## Contributing
 
 1. Fork it (<https://github.com/NeuraLegion/generic_actor/fork>)

--- a/spec/generic_actor_spec.cr
+++ b/spec/generic_actor_spec.cr
@@ -41,6 +41,52 @@ class Counter
   end
 end
 
+
+class CounterWithConstructor
+  include GenericActor
+
+  @value : Int32
+
+  def initialize(@value : Int32)
+    # Call GenericActor initialize
+    # to start GenericActor's fiber
+    initialize 
+  end
+
+  cast_def reset, nil do
+    @value = 0
+  end
+
+  cast_def add, {amount: Int32} do
+    raise ArgumentError.new("Negative amount are not allowed") unless amount >= 0
+    @value += amount
+  end
+
+  call_def get, nil, Int32 do
+    @value
+  end
+
+  call_def get_alt, {amount: Int32}, Int32 do
+    raise ArgumentError.new("Negative amount are not allowed") unless amount >= 0
+    @value + amount
+  end
+
+  call_def zero?, nil, Bool do
+    @value == 0
+  end
+
+  cast_def question?, nil do
+    # Check if cast can end with ?
+  end
+
+  call_def many_args_call, {a: Int32, b: Int32}, Int32 do
+    a + b
+  end
+
+  cast_def many_args_cast, {a: Int32, b: Int32} do
+  end
+end
+
 describe GenericActor do
   it "serialize messages" do
     c = Counter.new
@@ -76,6 +122,15 @@ describe GenericActor do
 
   it "compiles with multiple args" do
     c = Counter.new
+    c.many_args_call(a: 1, b: 2)
+    c.many_args_cast(a: 1, b: 2)
+  end
+
+
+  it "Works with class with constructor" do
+    c = CounterWithConstructor.new(100)
+    c.question?
+    c.zero?
     c.many_args_call(a: 1, b: 2)
     c.many_args_cast(a: 1, b: 2)
   end

--- a/src/generic_actor.cr
+++ b/src/generic_actor.cr
@@ -3,17 +3,15 @@ require "log"
 module GenericActor
   VERSION = "0.1.0"
 
-  macro included
-    @message_queue = Channel(Message).new(100)
+  @message_queue = Channel(Message).new(100)
 
-    private abstract struct Message
-    end
-
-    private def actor_handle(message : Message)
-      raise "Unhandled actor message #{message}"
-    end
+  private abstract struct Message
   end
 
+  private def actor_handle(message : Message)
+    raise "Unhandled actor message #{message}"
+  end
+  
   def initialize
     spawn do
       actor_loop


### PR DESCRIPTION
1. Removed redundant macro included
2. Added spec and doc about redefinition of `initialize` method 