### PR TITLE
feat: added statuses to generic actor message queue loop processing

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: generic_actor
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Bar Hofesh <bar.hofesh@gmail.com>
 
 # TODO: Update to "~> 1" once the time comes.
-crystal: ">= 0.36, < 2"
+crystal: ">= 0.36, < 1.5"
 
 license: MIT

--- a/src/generic_actor.cr
+++ b/src/generic_actor.cr
@@ -1,28 +1,72 @@
 require "log"
+require "mutex"
 
 module GenericActor
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 
-  @message_loop_started = Atomic::Flag.new
+  private enum ActorState
+    PENDING
+    PROCESSING
+    STOPPED
+  end
+
+  class AbuseStoppedActorException < Exception
+  end
+
+  @message_loop_state = ActorState::PENDING
+  @message_loop_state_mutex = Mutex.new
   @message_queue = Channel(Message).new(100)
+  @was_stop_action_performed = Atomic::Flag.new
+
+  def stop_actor
+    @message_loop_state_mutex.synchronize do
+      perform_stop_action if @message_loop_state == ActorState::PENDING
+      @message_loop_state = ActorState::STOPPED
+      @message_queue.close
+    end
+  end
+
+  protected def process_stop
+    # You can override process_stop to close resources you want
+  end
+
+  private def perform_stop_action
+    return unless @was_stop_action_performed.test_and_set
+    begin
+      process_stop
+    rescue e
+      Log.error {"Cought exception from process_stop: #{e}"}
+    end
+  end
+
+  private abstract struct Message
+  end
 
   private def check_message_loop
-    return unless @message_loop_started.test_and_set
-    spawn { actor_loop }
-  end
-  
-  private abstract struct Message
+    @message_loop_state_mutex.synchronize do
+      case @message_loop_state
+      when ActorState::PROCESSING
+        return
+      when ActorState::STOPPED
+        raise AbuseStoppedActorException.new
+      else
+        spawn { actor_loop }
+        @message_loop_state = ActorState::PROCESSING
+      end
+    end
   end
 
   private def actor_handle(message : Message)
     raise "Unhandled actor message #{message}"
   end
-  
-  def actor_loop
-    # TODO handle stop
+
+  private def actor_loop
     loop do
-      message = @message_queue.receive
-      actor_handle(message)
+      begin
+        actor_handle(@message_queue.receive)
+      rescue exception : Channel::ClosedError
+        return perform_stop_action
+      end
     end
   end
 
@@ -38,8 +82,8 @@ module GenericActor
     end
 
     def {{name}}({% if args %}*,{% for k, v in args %}{{k}} : {{v}},{% end %}{% end %}) : Nil
-      message = {{message_type}}.new({% if args %}{ {% for k, v in args %}{{k}}: {{k}},{% end %} }{% end %})
       check_message_loop
+      message = {{message_type}}.new({% if args %}{ {% for k, v in args %}{{k}}: {{k}},{% end %} }{% end %})
       @message_queue.send(message)
     end
 
@@ -62,7 +106,7 @@ module GenericActor
   end
 
   macro call_def(name, args, result, &block)
-    {% message_type = "M#{name}".tr("?", "").camelcase.id %}
+    {% message_type = "FutureM#{name}".tr("?", "").camelcase.id %}
     private struct {{message_type}} < Message
       @channel = Channel({{result}} | Exception).new(1)
 
@@ -73,14 +117,15 @@ module GenericActor
       end
       {% end %}
 
-      def reply_with
-        begin
-          @channel.send(yield)
-        rescue e
-          @channel.send(e)
-        end
+      def set_response(response : {{result}}) : Nil
+        @channel.send(response)
       end
 
+      def set_exception(exception : Exception) : Nil
+        @channel.send(exception)
+      end
+
+      # can raise Channel::ClosedError after stop_actor
       def await : {{result}}
         res = @channel.receive
 
@@ -93,10 +138,10 @@ module GenericActor
     end
 
     def {{name}}({% if args %}*,{% for k, v in args %}{{k}} : {{v}},{% end %}{% end %}) : {{result}}
-      message = {{message_type}}.new({% if args %}{ {% for k, v in args %}{{k}}: {{k}},{% end %} }{% end %})
-      check_message_loop
-      @message_queue.send(message)
-      message.await
+      check_message_loop  
+      future = {{message_type}}.new({% if args %}{ {% for k, v in args %}{{k}}: {{k}},{% end %} }{% end %})
+      @message_queue.send(future)
+      future.await
     end
 
     protected def process_{{name}}(__m : {{message_type}}) : {{result}}
@@ -108,8 +153,10 @@ module GenericActor
       {{ block.body }}
     end
 
-    private def actor_handle(message : {{message_type}})
-      message.reply_with { process_{{name}}(message) }
+    private def actor_handle(future : {{message_type}})
+      future.set_response(process_{{name}}(future))
+    rescue e
+      future.set_exception(e)
     end
   end
 end


### PR DESCRIPTION
Implementation of stop process function for actor concurrency model.
You can stop actors from any thread using #stop_actor method. After stopping the actor currently running(got from message queue tasks) stay running but they can't send the results to the caller. Also if you try to call stopped actor it will raise GenericActor::AbuseStoppedActorException.

Note: After the changes mechanic, specs became slower